### PR TITLE
Add Laravel 5.5+ service auto-detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
 # Laravel Spatial extension
 
 This package is fully untested, undocumented and unstable and is a combination of the two great packages:
-- [Laravel PostGIS extension](https://github.com/njbarrett/laravel-postgis)
-- [Laravel MySQL spatial extension](https://github.com/grimzy/laravel-mysql-spatial)
+
+-   [Laravel PostGIS extension](https://github.com/njbarrett/laravel-postgis)
+-   [Laravel MySQL spatial extension](https://github.com/grimzy/laravel-mysql-spatial)
 
 ## Installation
 
 Installation made super-easy with [composer](https://getcomposer.org):
-```
+
+```bash
 composer require apptimists/laravel-spatial
 ```
 
-Also add the `LaravelSpatial\SpatialServiceProvider::class` to your `config/app.php`.
+If you're using a Laravel version before 5.5, also add the `LaravelSpatial\SpatialServiceProvider::class` to your `config/app.php`.
 
 ## Requirements
 
@@ -22,15 +24,16 @@ If you try using it on a shared host which is not fulfilling those requirements,
 ## Usage
 
 We use the [GeoJson PHP Library](http://jmikola.github.io/geojson/) for describing spatial fields as GeoJSON object, e.g.:
-```
+
+```php
 use GeoJSON\Geometry\Point;
- 
+
 ...
- 
+
 $eloquent = new MyModel();
 $eloquent->location = new Point([49.7, 6.9]);
- 
+
 ...
- 
+
 $eloquent->save();
 ```

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,11 @@
     }
   },
   "extra": {
+    "laravel": {
+      "providers": [
+        "LaravelSpatial\\SpatialServiceProvider"
+      ]
+    },
     "branch-alias": {
       "dev-master": "1.0.x-dev"
     }


### PR DESCRIPTION
Laravel 5.5+ includes support for automatically registering service providers for project dependencies. This PR adds the `composer.json` entries needed to make this work.